### PR TITLE
Infinite scroll api call unlimited

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Your Component
 ```
 
 Your Controller
+
+Paging using page numbers
 ```
 export default Controller.extend({
     page: 1,
@@ -52,6 +54,20 @@ export default Controller.extend({
             return get(this, 'ajax').request(`names?page=${newPage}&search=${term}`).then(() => {
                 set(this, 'page', newPage);
             });
+        }
+    }
+});
+```
+Paging using page offset & limit
+```
+export default Controller.extend({
+    page: 1,
+    actions: {
+        search(term) {
+            return get(this, 'ajax').request(`names?search=${term}`);
+        },
+        async loadMore(term, select) {
+            return get(this, 'ajax').request(`names?search=${term}&offset=${get(select, 'resultsCount')}&limit=10`);
         }
     }
 });

--- a/addon/components/power-select-with-scroll.js
+++ b/addon/components/power-select-with-scroll.js
@@ -1,6 +1,6 @@
 import PowerSelect from 'ember-power-select/components/power-select';
 import { countOptions } from 'ember-power-select/utils/group-utils';
-import { get } from '@ember/object';
+import { get, set } from '@ember/object';
 import { tryInvoke } from '@ember/utils';
 import { isBlank } from '@ember/utils';
 
@@ -9,7 +9,7 @@ export default PowerSelect.extend({
     canLoadMore: true,
     actions: {
         search(term) {
-          this.updateState({ canLoadMore: true });
+          set(this, 'canLoadMore', true);
           if (isBlank(term)) {
               this.updateState({
                   results: get(this, 'options'),
@@ -37,9 +37,9 @@ export default PowerSelect.extend({
                         _rawSearchResults: newResults,
                         resultsCount: countOptions(plainArray),
                         lastSearchedText: term,
-                        loading: false,
-                        canLoadMore: get(results, 'length') !== 0
+                        loading: false
                     });
+                    set(this, 'canLoadMore', get(results, 'length') !== 0);
                     this.resetHighlighted();
                 }).catch(() => {
                     this.updateState({ lastSearchedText: term, loading: false });

--- a/addon/components/power-select-with-scroll.js
+++ b/addon/components/power-select-with-scroll.js
@@ -6,6 +6,7 @@ import { isBlank } from '@ember/utils';
 
 export default PowerSelect.extend({
     mustShowSearchMessage: false,
+    canLoadMore: true,
     actions: {
         search(term) {
           this.updateState({ canLoadMore: true });

--- a/addon/components/power-select-with-scroll.js
+++ b/addon/components/power-select-with-scroll.js
@@ -35,7 +35,7 @@ export default PowerSelect.extend({
                     this.updateState({
                         results: newResults,
                         _rawSearchResults: newResults,
-                        resultsCount: countOptions(plainArray),
+                        resultsCount: countOptions(newResults),
                         lastSearchedText: term,
                         loading: false
                     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-power-select-infinity",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Ember Power Select with Infinity Paging and Occlusion Rendering",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Disabling the ability to make infinite api calls to load more data if 0 results are returned