### PR TITLE
Misc. Fixes + Working keyboard nav by default (uses @renderAll on vert-collection)

### DIFF
--- a/addon/components/power-select-infinity.hbs
+++ b/addon/components/power-select-infinity.hbs
@@ -30,6 +30,8 @@
             createMessage=this.createMessage
             labelPath=@labelPath
             allowClear=this.allowClear
+            triggerClass=this.triggerClass
+            renderAll=@renderAll
         )
         @extra
     }}

--- a/addon/components/power-select-infinity.ts
+++ b/addon/components/power-select-infinity.ts
@@ -172,6 +172,14 @@ export interface PowerSelectInfinityArgs<T> extends PowerSelectArgs<T, PowerSele
      * @memberof PowerSelectInfinityArgs
      */
     staticHeight?: boolean;
+
+    /**
+     * Used by ember-vertical-collection to determine if all
+     * elements should be rendered or not.
+     *
+     * @type {boolean}
+     */
+    renderAll?: boolean;
 }
 
 export default class PowerSelectInfinity<T> extends Component<PowerSelectInfinityArgs<T>> {

--- a/addon/components/power-select-infinity.ts
+++ b/addon/components/power-select-infinity.ts
@@ -20,6 +20,8 @@ export type PowerSelectInfinityExtra = Pick<
     | 'loadingComponent'
     | 'createOption'
     | 'allowClear'
+    | 'renderAll'
+    | 'triggerClass'
 > & {
     /**
      *  Whether or not the user should be given the option to create if no options found

--- a/addon/components/power-select-infinity/ds-model.hbs
+++ b/addon/components/power-select-infinity/ds-model.hbs
@@ -54,6 +54,7 @@
     @triggerId={{@triggerId}}
     @triggerRole={{@triggerRole}}
     @verticalPosition={{@verticalPosition}}
+    @renderAll={{@renderAll}}
     ...attributes
     as |option select|
 >

--- a/addon/components/power-select-infinity/ds-model.ts
+++ b/addon/components/power-select-infinity/ds-model.ts
@@ -217,7 +217,7 @@ export default class PowerSelectInfinityModel<T> extends Component<PowerSelectIn
             }
             return results;
         } catch (errors) {
-            return errors;
+            return err(errors);
         }
     }
 

--- a/addon/components/power-select-infinity/options.hbs
+++ b/addon/components/power-select-infinity/options.hbs
@@ -1,9 +1,11 @@
 <ul
     role="listbox"
     class="ember-power-select-options-list"
-    aria-controls="ember-power-select-options-{{@select.uniqueId}}"
+    {{!-- The keyboard navigation is currently broken in Ember-PowerSelect v4. The selector for navigation uses -trigger- for the aria-control instead of options. This should be changed back to -options- when v5 is used and stable. --}}
+    aria-controls="ember-power-select-trigger-{{@select.uniqueId}}"
     ...attributes
     {{did-insert this.addHandlers}}
+    {{will-destroy this.removeHandlers}}
 >
     <VerticalCollection
         @items={{@select.options}}
@@ -11,6 +13,7 @@
         @staticHeight={{@extra.staticHeight}}
         @bufferSize={{@extra.bufferSize}}
         @lastReached={{@extra.onLastReached}}
+        @renderAll={{or @extra.renderAll true}}
         @containerSelector=".ember-power-select-options"
         as |opt index|
     >

--- a/addon/components/power-select-infinity/options.hbs
+++ b/addon/components/power-select-infinity/options.hbs
@@ -13,7 +13,7 @@
         @staticHeight={{@extra.staticHeight}}
         @bufferSize={{@extra.bufferSize}}
         @lastReached={{@extra.onLastReached}}
-        @renderAll={{or @extra.renderAll true}}
+        @renderAll={{this.renderAll}}
         @containerSelector=".ember-power-select-options"
         as |opt index|
     >

--- a/addon/components/power-select-infinity/options.ts
+++ b/addon/components/power-select-infinity/options.ts
@@ -17,5 +17,9 @@ export default class PowerSelectInfinityOptions<T, E extends PowerSelectInfinity
     get estimateHeight() {
         return this.args.extra.estimateHeight ?? 30;
     }
+
+    get renderAll() {
+        return this.args.extra.renderAll ?? true;
+    }
 }
 // setComponentTemplate(Template, PowerSelectInfinityOptions);

--- a/addon/components/power-select-infinity/trigger-search.hbs
+++ b/addon/components/power-select-infinity/trigger-search.hbs
@@ -5,7 +5,7 @@
         value={{this.text}}
         placeholder={{@placeholder}}
         maxlength="256"
-        class="ember-power-select-trigger-input power-select-search-input position-relative text-md form-control"
+        class="ember-power-select-trigger-input power-select-search-input position-relative text-md form-control {{@extra.triggerClass}}"
         autocomplete="off"
         autocorrect="off"
         autocapitalize="off"
@@ -13,7 +13,7 @@
         id="ember-power-select-infinity-trigger-{{@select.uniqueId}}"
         aria-controls={{@listboxId}}
         disabled={{@select.disabled}}
-        tabindex={{-1}}
+        tabindex={{0}}
         {{on "focus" @onFocus}}
         {{on "blur" (fn this.onBlur @select)}}
         {{on "input" @onInput}}

--- a/addon/components/power-select-infinity/trigger-search.ts
+++ b/addon/components/power-select-infinity/trigger-search.ts
@@ -8,14 +8,16 @@ import { PowerSelectTriggerArgs } from 'ember-power-select/components/power-sele
 
 import { PowerSelectInfinityExtra } from '@gavant/ember-power-select-infinity/components/power-select-infinity';
 
-const KEYCODE_BACKSPACE = 8;
-const KEYCODE_UP_ARROW = 38;
-const KEYCODE_DOWN_ARROW = 40;
-const KEYCODE_0 = 48;
-const KEYCODE_Z = 90;
-const KEYCODE_SPACE = 32;
-const KEYCODE_ENTER = 13;
-const KEYCODE_ESCAPE = 27;
+const KEY_BACKSPACE = 'Backspace';
+const KEY_UP_ARROW = 'ArrowUp';
+const KEY_DOWN_ARROW = 'ArrowDown';
+const KEY_0 = '0';
+const KEY_9 = '9';
+const KEY_A = 'A';
+const KEY_Z = 'Z';
+const KEY_SPACE = ' ';
+const KEY_ENTER = 'Enter';
+const KEY_ESCAPE = 'Escape';
 
 export default class PowerSelectInfinityTriggerSearch<T> extends Component<
     PowerSelectTriggerArgs<T, PowerSelectInfinityExtra>
@@ -78,22 +80,28 @@ export default class PowerSelectInfinityTriggerSearch<T> extends Component<
     //@ts-ignore
     handleKeydown(e: KeyboardEvent) {
         // up or down arrow and if not open, no-op and prevent parent handlers from being notified
-        if ([KEYCODE_UP_ARROW, KEYCODE_DOWN_ARROW].indexOf(e.keyCode) > -1 && !this.args.select.isOpen) {
+        if ([KEY_UP_ARROW, KEY_DOWN_ARROW].indexOf(e.key) > -1 && !this.args.select.isOpen) {
             e.stopPropagation();
             return;
         }
-        const isLetter = (e.keyCode >= KEYCODE_0 && e.keyCode <= KEYCODE_Z) || e.keyCode === KEYCODE_SPACE; // Keys 0-9, a-z or SPACE
+        const isLetter =
+            (e.key.length === 1 && ((e.key >= KEY_0 && e.key <= KEY_9) || (e.key >= KEY_A && e.key <= KEY_Z))) ||
+            e.key === KEY_SPACE; // Keys 0-9, a-z or SPACE
         // if isLetter, escape or enter, prevent parent handlers from being notified
-        if (isLetter || [KEYCODE_ENTER, KEYCODE_ESCAPE].indexOf(e.keyCode) > -1) {
+        if (isLetter || [KEY_ENTER, KEY_ESCAPE].indexOf(e.key) > -1) {
             const select = this.args.select;
             // open if loading msg configured
             if (!select.isOpen && this.args.loadingMessage) {
                 scheduleOnce('afterRender', null, select.actions.open);
             }
             e.stopPropagation();
+            // Prevent Enter from submitting forms
+            if (e.key === KEY_ENTER) {
+                e.preventDefault();
+            }
         }
 
-        if (e.keyCode === KEYCODE_BACKSPACE && this.args.select.selected) {
+        if (e.key === KEY_BACKSPACE && this.args.select.selected) {
             const select = this.args.select;
             e.stopPropagation();
             if (select.selected) {
@@ -103,7 +111,7 @@ export default class PowerSelectInfinityTriggerSearch<T> extends Component<
             scheduleOnce('afterRender', null, select.actions.open);
         }
 
-        if (e.keyCode === KEYCODE_ENTER && this.args.extra?.showCreateMessage && this.args.extra.createOption) {
+        if (e.key === KEY_ENTER && this.args.extra?.showCreateMessage && this.args.extra.createOption) {
             const select = this.args.select;
             this.args.extra.createOption(select.searchText);
             scheduleOnce('afterRender', null, select.actions.close);


### PR DESCRIPTION
- Allows keyboard navigation to always work by default. This takes advantage of ember-vertical-collection's ability to "render-all" but can be toggled off when necessary by passing in `@renderAll={{false}}`.
- Removes the usage of deprecated `keyCode` on KeyboardEvent
- Changes aria-control on options container to the correct value for Ember-Power-Select @ v4, should be changed back when upgrading to v5, as it's been fixed there.
- Change tabindex to 0 on trigger to allow for keyboard navigation to focus the input.
- Propagation of "Enter" prevented to allow users to select an option using "Enter" without submitting the entire form (this should possibly have an override or better method of handling, to allow both to occur)